### PR TITLE
Player permission viewing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+install: true

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.9
+version: 2.2.91
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.92
+version: 2.2.93
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,8 @@ commands:
    nlleg:
    nllgt:
    nllpt:
+   nllci:
+   nltaai:
 permissions:
    namelayer.admin:
       default: op

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.100
+version: 2.3.0
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.96
+version: 2.2.97
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.93
+version: 2.2.94
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.94
+version: 2.2.95
 load: startup
 author: Rourke750
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: NameLayer
 main: vg.civcraft.mc.namelayer.NameLayerPlugin
-version: 2.2.91
+version: 2.2.92
 load: startup
 author: Rourke750
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.92</version>
+  <version>2.2.93</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.9</version>
+  <version>2.2.91</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.96-${build.number}</version>
+  <version>2.2.97-${build.number}</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.91</version>
+  <version>2.2.92</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.94</version>
+  <version>2.2.95-${build.number}</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.93</version>
+  <version>2.2.94</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>vg.civcraft.mc.namelayer</groupId>
   <artifactId>NameLayer</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.97-${build.number}</version>
+  <version>2.3.0-${build.number}</version>
   <name>NameLayer</name>
   <url>https://github.com/Civcraft/NameLayer/</url>
   

--- a/src/vg/civcraft/mc/namelayer/GroupManager.java
+++ b/src/vg/civcraft/mc/namelayer/GroupManager.java
@@ -42,6 +42,7 @@ public class GroupManager{
 	}
 	
 	public boolean deleteGroup(String groupName){
+		groupName = groupName.toLowerCase();
 		Group g = getGroup(groupName);
 		GroupDeleteEvent event = new GroupDeleteEvent(g, false);
 		Bukkit.getPluginManager().callEvent(event);
@@ -103,6 +104,7 @@ public class GroupManager{
 	 * Saves me code so I can always grab a group if it is already loaded while not needing to check db.
 	 */
 	public static Group getGroup(String groupName){
+		groupName = groupName.toLowerCase();
 		if (groups.containsKey(groupName))
 			return groups.get(groupName);
 		else{ 

--- a/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
@@ -67,7 +67,7 @@ public class GroupStats extends PlayerCommand {
 					message += "No members for the PlayerType " + type.name() + ".\n";
 			}
 			message += "That makes " + g.getAllMembers().size() + " members total.";
-			if (!p.isOnline()) // meh be safe
+			if (p != null && !p.isOnline()) // meh be safe
 				return;
 			p.sendMessage(message);
 		}

--- a/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/GroupStats.java
@@ -33,6 +33,10 @@ public class GroupStats extends PlayerCommand {
 		Group g = gm.getGroup(args[0]);
 		UUID uuid = NameAPI.getUUID(p.getName());
 		
+		if (g == null){
+			p.sendMessage(ChatColor.RED + "That group does not exist.");
+			return true;
+		}
 		if (!g.isMember(uuid) && !(p.isOp() || p.hasPermission("namelayer.admin"))){
 			p.sendMessage(ChatColor.RED + "You are not on this group.");
 			return true;

--- a/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -94,13 +94,16 @@ public class InvitePlayer extends PlayerCommand{
 		
 		group.addInvite(uuid, pType);
 		OfflinePlayer invitee = Bukkit.getOfflinePlayer(uuid);
-		
-		if (invitee.isOnline()){
+		boolean shouldAutoAccept = db.shouldAutoAcceptGroups(invitee.getUniqueId());
+		if (invitee.isOnline() && !shouldAutoAccept){
 			Player oInvitee = (Player) invitee;
 			oInvitee.sendMessage(ChatColor.GREEN + "You have been invited to the group " + group.getName() +" by " + p.getName() +".\n" +
 					"Use the command /nlag <group> to accept.\n"
 					+ "If you wish to toggle invites so they always are accepted please run /nltaai");
 			p.sendMessage(ChatColor.GREEN + "The invitation has been sent.");
+		}
+		else if(shouldAutoAccept){
+			p.sendMessage(ChatColor.GREEN + "Player has auto accepted into the group.");
 		}
 		else{
 			p.sendMessage(ChatColor.GREEN + "Player is offline and will be notified on log in.");

--- a/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -63,6 +63,10 @@ public class InvitePlayer extends PlayerCommand{
 		
 		GroupPermission perm = gm.getPermissionforGroup(group);
 		PlayerType t = group.getPlayerType(executor); // playertype for the player running the command.
+		if (t == null){
+			p.sendMessage(ChatColor.RED + "You are not on that group.");
+			return true;
+		}
 		boolean allowed = false;
 		switch (pType){ // depending on the type the executor wants to add the player to
 		case MEMBERS:

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListGroups.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.group.Group;
 
 public class ListGroups extends PlayerCommand {
 
@@ -45,7 +46,8 @@ public class ListGroups extends PlayerCommand {
 		names += "Page " + start + " of " + pages + ".\n"
 				+ "Groups are as follows: \n";
 		for (int x = (start-1) * 10, z = 1; x < groups.size() && z <= 10; x++, z++){
-			names += groups.get(x) + "\n";
+			Group g = gm.getGroup(groups.get(x));
+			names += g.getName() + ": (PlayerType) " + g.getPlayerType(uuid).toString() + "\n";
 		}
 		p.sendMessage(names);
 		return true;

--- a/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/ListMembers.java
@@ -31,6 +31,10 @@ public class ListMembers extends PlayerCommand{
 		Player p = (Player) sender;
 		Group g = gm.getGroup(args[0]);
 		UUID uuid = NameAPI.getUUID(p.getName());
+		if (g == null){
+			p.sendMessage(ChatColor.RED + "That group does not exist.");
+			return true;
+		}
 		if (!g.isMember(uuid) && !(p.isOp() || p.hasPermission("namelayer.admin"))){
 			p.sendMessage(ChatColor.RED + "You are not on this group.");
 			return true;

--- a/src/vg/civcraft/mc/namelayer/command/commands/PromotePlayer.java
+++ b/src/vg/civcraft/mc/namelayer/command/commands/PromotePlayer.java
@@ -43,13 +43,13 @@ public class PromotePlayer extends PlayerCommand{
 		
 		UUID promotee = NameAPI.getUUID(args[1]);
 		
-		if(promotee == executor){
-			p.sendMessage(ChatColor.RED + "You cannot promote yourself");
+		if(promotee ==null){
+			p.sendMessage(ChatColor.RED + "That player does not exist");
 			return true;
 		}
 		
-		if(promotee ==null){
-			p.sendMessage(ChatColor.RED + "That player does not exist");
+		if(promotee.equals(executor)){
+			p.sendMessage(ChatColor.RED + "You cannot promote yourself");
 			return true;
 		}
 		

--- a/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -386,7 +386,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public Group getGroup(String groupName){
+	public synchronized Group getGroup(String groupName){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			getGroup.setString(1, groupName);

--- a/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -450,7 +450,7 @@ public class GroupManagerDao {
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			addMember.setString(1, member.toString());
-			addMember.setString(2,role.name());
+			addMember.setString(2, role.name());
 			addMember.setString(3, faction);
 			addMember.execute();
 		} catch (SQLException e) {

--- a/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -288,8 +288,8 @@ public class GroupManagerDao {
 				+ "inner join faction_id id on id.group_name = ? "
 				+ "where fm.group_id = id.group_id and fm.role = ?");
 		removeMember = db.prepareStatement("delete fm.* from faction_member fm "
-				+ "inner join faction_id fi on fi.group_name = ?"
-				+ "where fm.group_id = fi.group_id and fm.member_name = ?");
+				+ "inner join faction_id fi on fi.group_id = fm.group_id "
+				+ "where fm.member_name = ? and fi.group_name =?");
 		
 		addSubGroup = db.prepareStatement("insert into subgroup (group_id, sub_group_id) " +
 				"select g.group_id, sg.group_id from faction_id g "

--- a/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -353,7 +353,7 @@ public class GroupManagerDao {
 	 * @param pluginname- The plugin name.
 	 * @return Returns the new version of the db.
 	 */
-	public int updateVersion(int version, String pluginname){
+	public synchronized int updateVersion(int version, String pluginname){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 		try {
@@ -368,7 +368,7 @@ public class GroupManagerDao {
 		return ++version;
 	}
 	
-	public void createGroup(String group, UUID owner, String password, GroupType type){
+	public synchronized void createGroup(String group, UUID owner, String password, GroupType type){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			String own = null;
@@ -419,7 +419,7 @@ public class GroupManagerDao {
 		return null;
 	}
 	
-	public List<String> getGroupNames(UUID uuid){
+	public synchronized List<String> getGroupNames(UUID uuid){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		List<String> groups = new ArrayList<String>();
 		try {
@@ -434,7 +434,7 @@ public class GroupManagerDao {
 		return groups;
 	}
 	
-	public void deleteGroup(String groupName){
+	public synchronized void deleteGroup(String groupName){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			deleteGroup.setString(1, groupName);
@@ -446,7 +446,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public void addMember(UUID member, String faction, PlayerType role){
+	public synchronized void addMember(UUID member, String faction, PlayerType role){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			addMember.setString(1, member.toString());
@@ -459,7 +459,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public List<UUID> getAllMembers(String groupName, PlayerType role){
+	public synchronized List<UUID> getAllMembers(String groupName, PlayerType role){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		List<UUID> members = new ArrayList<UUID>();
 		try {
@@ -480,7 +480,7 @@ public class GroupManagerDao {
 		return members;
 	}
 	
-	public void removeMember(UUID member, String group){
+	public synchronized void removeMember(UUID member, String group){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			removeMember.setString(1, member.toString());
@@ -492,7 +492,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public void addSubGroup(String group, String subGroup){
+	public synchronized void addSubGroup(String group, String subGroup){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			addSubGroup.setString(1, group);
@@ -504,7 +504,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public List<Group> getSubGroups(String group){
+	public synchronized List<Group> getSubGroups(String group){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		List<Group> groups = new ArrayList<Group>();
 		try {
@@ -521,7 +521,7 @@ public class GroupManagerDao {
 		return groups;
 	}
 	
-	public Group getSuperGroup(String subGroup){
+	public synchronized Group getSuperGroup(String subGroup){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			getSuperGroup.setString(1, subGroup);
@@ -536,7 +536,7 @@ public class GroupManagerDao {
 		return null;
 	}
 	
-	public void removeSubGroup(String group, String subGroup){
+	public synchronized void removeSubGroup(String group, String subGroup){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			removeSubGroup.setString(1, group);
@@ -548,7 +548,7 @@ public class GroupManagerDao {
 		}
 	}
 
-	public void addPermission(String groupName, String role, String values){
+	public synchronized void addPermission(String groupName, String role, String values){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			addPerm.setString(1, role);
@@ -561,7 +561,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public Map<PlayerType, List<PermissionType>> getPermissions(String group){
+	public synchronized Map<PlayerType, List<PermissionType>> getPermissions(String group){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		Map<PlayerType, List<PermissionType>> perms = new HashMap<PlayerType, List<PermissionType>>();
 		try {
@@ -583,7 +583,7 @@ public class GroupManagerDao {
 		return perms;
 	}
 	
-	public void updatePermissions(String group, PlayerType pType, String perms){
+	public synchronized void updatePermissions(String group, PlayerType pType, String perms){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			updatePerm.setString(1, perms);
@@ -596,7 +596,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public int countGroups(){
+	public synchronized int countGroups(){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			ResultSet set = countGroups.executeQuery();
@@ -608,7 +608,7 @@ public class GroupManagerDao {
 		return 0;
 	}
 	
-	public void mergeGroup(String groupName, String toMerge){
+	public synchronized void mergeGroup(String groupName, String toMerge){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			mergeGroup.setString(1, groupName);
@@ -620,7 +620,7 @@ public class GroupManagerDao {
 		}
 	}
 	
-	public void updatePassword(String groupName, String password){
+	public synchronized void updatePassword(String groupName, String password){
 		NameLayerPlugin.reconnectAndReintializeStatements();
 		try {
 			updatePassword.setString(1, password);
@@ -636,7 +636,7 @@ public class GroupManagerDao {
 	 * Adds the uuid to the db if they should auto accept groups when invited.
 	 * @param uuid
 	 */
-	public void autoAcceptGroups(UUID uuid){
+	public synchronized void autoAcceptGroups(UUID uuid){
 		try {
 			addAutoAcceptGroup.setString(1, uuid.toString());
 			addAutoAcceptGroup.execute();
@@ -650,7 +650,7 @@ public class GroupManagerDao {
 	 * @param uuid- The UUID of the player.
 	 * @return Returns true if they should auto accept.
 	 */
-	public boolean shouldAutoAcceptGroups(UUID uuid){
+	public synchronized boolean shouldAutoAcceptGroups(UUID uuid){
 		try {
 			getAutoAcceptGroup.setString(1, uuid.toString());
 			ResultSet set = getAutoAcceptGroup.executeQuery();
@@ -662,7 +662,7 @@ public class GroupManagerDao {
 		return false;
 	}
 	
-	public void removeAutoAcceptGroup(UUID uuid){
+	public synchronized void removeAutoAcceptGroup(UUID uuid){
 		try {
 			removeAutoAcceptGroup.setString(1, uuid.toString());
 			removeAutoAcceptGroup.execute();

--- a/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
+++ b/src/vg/civcraft/mc/namelayer/database/GroupManagerDao.java
@@ -226,7 +226,7 @@ public class GroupManagerDao {
 				"update ignore faction_member fm "
 				+ "inner join faction_id fi on fi.group_name = groupName "
 				+ "inner join faction_id fii on fii.group_name = tomerge "
-				+ "set fm.group_id = fi.group_name "
+				+ "set fm.group_id = fi.group_id "
 				+ "where fm.group_id = fii.group_id;" +
 				"delete fm.* from faction_member fm "
 				+ "inner join faction_id fi on fi.group_name = tomerge "

--- a/src/vg/civcraft/mc/namelayer/group/groups/PrivateGroup.java
+++ b/src/vg/civcraft/mc/namelayer/group/groups/PrivateGroup.java
@@ -26,6 +26,8 @@ public class PrivateGroup extends Group{
 	}
 	@Override
 	public void addMember(UUID uuid, PlayerType type){
+		if (players.containsKey(uuid))
+			db.removeMember(uuid, super.groupName);
 		db.addMember(uuid, groupName, type);
 		players.put(uuid, type);
 		for (Group g: subGroups.get(this))

--- a/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
+++ b/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
@@ -23,7 +23,9 @@ public class PlayerListener implements Listener{
 	public void playerJoinEvent(PlayerJoinEvent event){
 		Player p = event.getPlayer();
 		UUID uuid = p.getUniqueId();
-		if (!notifications.containsKey(uuid) && !notifications.get(uuid).isEmpty())
+		if (!notifications.containsKey(uuid) || notifications.get(uuid).isEmpty())
+			return;
+		if (notifications.get(uuid).isEmpty())
 			return;
 		String x = "You have been invited to the following groups while you were away: ";
 		

--- a/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
+++ b/src/vg/civcraft/mc/namelayer/listeners/PlayerListener.java
@@ -23,7 +23,7 @@ public class PlayerListener implements Listener{
 	public void playerJoinEvent(PlayerJoinEvent event){
 		Player p = event.getPlayer();
 		UUID uuid = p.getUniqueId();
-		if (!notifications.containsKey(uuid))
+		if (!notifications.containsKey(uuid) && !notifications.get(uuid).isEmpty())
 			return;
 		String x = "You have been invited to the following groups while you were away: ";
 		

--- a/src/vg/civcraft/mc/namelayer/permission/GroupPermission.java
+++ b/src/vg/civcraft/mc/namelayer/permission/GroupPermission.java
@@ -33,7 +33,8 @@ public class GroupPermission {
 		if (type == null || type.length == 0)
 			return true; // If the player is even a member return true
 		if (group instanceof PublicGroup){
-			switch (type[0]){
+			for (int x = 0; x < type.length; x++)
+			switch (type[x]){
 			case DOORS:
 			case CHESTS:
 				return true;


### PR DESCRIPTION
Allows players to view their specific permissions for a group by typing /nllp groupname, leaving off the permissiontype at the end.